### PR TITLE
Update dependency from cprice404/inifile to puppetlabs/inifile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,5 +9,5 @@ project_page 'http://github.com/softek/puppet-zabbixagent'
 
 ## Add dependencies, if any:
 dependency 'puppetlabs/stdlib', '>= 3.0.0'
-dependency 'cprice404/inifile', '>= 0.9.0'
+dependency 'puppetlabs/inifile', '>= 0.9.0'
 dependency 'stahnma/epel', '>= 0.0.3'


### PR DESCRIPTION
Using this module as-is results in a nasty deprecation warning:

```
==> client: Warning: cprice404-inifile is deprecated; please update to puppetlabs-inifile
==> client: Warning: cprice404-inifile is deprecated; please update to puppetlabs-inifile
```

Update dependencies to use `puppetlabs/inifile` module as it appears that the module simply moved namespaces.
