### PR TITLE
as zabbix20 is the only package available...

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class zabbixagent(
     centos: {
       include epel
 
-      package {'zabbix-agent' :
+      package {'zabbix20-agent' :
         ensure  => installed,
         require => Yumrepo["epel"]
       }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class zabbixagent(
 
       file { '/etc/zabbix/zabbix_agentd':
         ensure  => directory,
-        require => Package['zabbix-agent'],
+        require => Package['zabbix20-agent'],
       }
     }
     windows: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class zabbixagent(
       service {'zabbix-agent' :
         ensure  => running,
         enable  => true,
-        require => Package['zabbix-agent'],
+        require => Package['zabbix20-agent'],
       }
 
       ini_setting { 'servers setting':


### PR DESCRIPTION
EPEL only lists zabbix20-agent in their repositories, so this module no longer works out of the box with CentOS installs. 

Modified package name in order to match current listing in EPEL.
